### PR TITLE
Added error handling for malformed UTF-8

### DIFF
--- a/tumblr_backup.py
+++ b/tumblr_backup.py
@@ -215,7 +215,7 @@ def get_style():
             return
         css = css.replace('\r', '').replace('\n    ', '\n')
         with open_text(theme_dir, 'style.css') as f:
-            f.write(css + '\n')
+            f.write(css.decode('UTF-8', 'replace') + '\n')
 
 
 class TumblrBackup:


### PR DESCRIPTION
It's possible for malformed characters to be present in the CSS
presented by Tumblr. This change ensures that any malformed UTF-8 is
replaced with ? characters.
