### PR TITLE
Adding video/audio download support

### DIFF
--- a/tumblr_backup.md
+++ b/tumblr_backup.md
@@ -39,6 +39,10 @@ You can see an example of its output [on my home page](http://drbeat.li/tumblr).
     -D, --dirs            save each post in its own folder
     -q, --quiet           suppress progress messages
     -i, --incremental     incremental backup mode
+    -k, --skip-media      do not save any media; link to Tumblr instead
+    -K, --skip-external   do not save external videos; link to Tumblr instead
+    -M, --max-filesize=SIZE   Do not download any external videos larger than SIZE
+                          (e.g. 50k or 44.6m)
     -j, --json            save the original JSON source
     -b, --blosxom         save the posts in blosxom format
     -r, --reverse-month   reverse the post order in the monthly archives


### PR DESCRIPTION
Fixes https://github.com/bbolli/tumblr-utils/issues/32 :
- Audio files hosted on Tumblr and Soundcloud are now downloaded and
  embedded into an HTML5 audio tag.
- Video files hosted on Tumblr are downloaded and embedded into a video
  tag.
- External video files can be downloaded if Youtube-DL is installed on
  the system.
- The option -k now skips all medias download.
- The new option -K skips external videos download.
- The new option -M skips _external_ videos which have a size over the
  specified limit.

I switched the images folder to a 'media' folder. But I now realise it may be stupid for backward compatibility.
Let me now what you think of this PR, and I'll provide fixes accordingly.
