### PR TITLE
triple HTTP timeout threshold

### DIFF
--- a/tumblr_backup.py
+++ b/tumblr_backup.py
@@ -86,7 +86,7 @@ TAG_ANY = '__all__'
 
 MAX_POSTS = 50
 
-HTTP_TIMEOUT = 30
+HTTP_TIMEOUT = 90
 HTTP_CHUNK_SIZE = 1024 * 1024
 
 # bb-tumblr-backup API key


### PR DESCRIPTION
All my 404s on naked-yogi are now legitimate 404s and not timeouts. I'm raising it this high to be safe because some people work through VPNs or torrent while ripping these blogs.