### PR TITLE
Change mechanism for default blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+settings.py

--- a/settings.py.example
+++ b/settings.py.example
@@ -1,0 +1,3 @@
+DEFAULT_BLOGS = [
+    'example',
+]

--- a/tumblr_backup.md
+++ b/tumblr_backup.md
@@ -109,6 +109,11 @@ determine the locale for month names and the date/time format.
 The exit code is 0 if at least one post has been backed up, 1 if no post has
 been backed up, 2 on invocation errors, or 3 if the backup was interrupted.
 
+### Backup via settings.py
+
+To backup a list of tumblr addresses, copy `settings.py.example` to  
+`settings.py`, and add the addresses to the list in that file.
+
 
 ## 3. Operation
 

--- a/tumblr_backup.py
+++ b/tumblr_backup.py
@@ -27,7 +27,10 @@ import urllib2
 import urlparse
 from xml.sax.saxutils import escape
 
-import settings
+try:
+    from settings import DEFAULT_BLOGS
+except:
+    raise ImportError("Create a settings.py file. See settings.py.example")
 
 # extra optional packages
 try:
@@ -38,9 +41,6 @@ try:
     import youtube_dl
 except ImportError:
     youtube_dl = None
-
-# default blog name(s)
-DEFAULT_BLOGS = settings.DEFAULT_BLOGS
 
 # Format of displayed tags
 TAG_FMT = '#%s'

--- a/tumblr_backup.py
+++ b/tumblr_backup.py
@@ -27,6 +27,8 @@ import urllib2
 import urlparse
 from xml.sax.saxutils import escape
 
+import settings
+
 # extra optional packages
 try:
     import pyexiv2
@@ -38,7 +40,7 @@ except ImportError:
     youtube_dl = None
 
 # default blog name(s)
-DEFAULT_BLOGS = ['bbolli']
+DEFAULT_BLOGS = settings.DEFAULT_BLOGS
 
 # Format of displayed tags
 TAG_FMT = '#%s'


### PR DESCRIPTION
This allows people to define their own DEFAULT_BLOGS in a settings file, and takes the data "bbolli" out of the code.