### PR TITLE
[youtube-dl] fix media filename in template

### DIFF
--- a/tumblr_backup.py
+++ b/tumblr_backup.py
@@ -34,6 +34,7 @@ except ImportError:
     pyexiv2 = None
 try:
     import youtube_dl
+    from youtube_dl.utils import sanitize_filename
 except ImportError:
     youtube_dl = None
 
@@ -670,14 +671,15 @@ class TumblrPost:
 
     def get_youtube_url(self, youtube_url):
         # determine the media file name
+        filetmpl = u'%(id)s_%(uploader_id)s_%(title)s.%(ext)s'
         ydl = youtube_dl.YoutubeDL({
-            'outtmpl': join(self.media_folder, u'%(id)s_%(uploader_id)s_%(title)s.%(ext)s'),
+            'outtmpl': join(self.media_folder, filetmpl),
             'quiet': True, 'restrictfilenames': True, 'noplaylist': True
         })
         ydl.add_default_info_extractors()
         try:
             result = ydl.extract_info(youtube_url, download=False)
-            media_filename = ydl.prepare_filename(result)
+            media_filename = sanitize_filename(filetmpl % result['entries'][0], restricted=True)
         except:
             return ''
 


### PR DESCRIPTION
In some cases, youtube-dl.prepare_filename does not return a filename corresponding to the requested output template. This fix makes it sure it is coherent.