### PR TITLE
youtube-dl opts spruce up/stability enhancements

### DIFF
--- a/tumblr_backup.py
+++ b/tumblr_backup.py
@@ -709,7 +709,14 @@ class TumblrPost:
         filetmpl = u'%(id)s_%(uploader_id)s_%(title)s.%(ext)s'
         ydl = youtube_dl.YoutubeDL({
             'outtmpl': join(self.media_folder, filetmpl),
-            'quiet': True, 'restrictfilenames': True, 'noplaylist': True
+            'quiet': True, 
+            'restrictfilenames': True, 
+            'noplaylist': True,
+            'continuedl': True,
+            'nooverwrites': True,
+            'retries': 3000,		
+            'fragment_retries': 3000,
+            'ignoreerrors': True
         })
         ydl.add_default_info_extractors()
         try:


### PR DESCRIPTION
- Opt per line for better readability.
- Continue download on failure and subsequent re-rip
- Do not over-write file if there already on a subsequent re-rip. This will speed repeated video-heavy blog archival greatly.
- Retries set to high number to ensure video is grabbed.
- Fragment retries set to high number to ensure video is grabbed
- Video errors, like geo-blocked youtube videos, will have the error printed to stdout for more information.